### PR TITLE
chore: migrate automl synth.py to bazel

### DIFF
--- a/grpc-google-cloud-automl-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-automl-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.0 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/language/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-automl-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-automl-v1/clirr-ignored-differences.xml
@@ -4,7 +4,7 @@
   <difference>
     <!-- TODO: remove after 1.1.0 released -->
     <differenceType>6001</differenceType>
-    <className>com/google/cloud/language/v1/*Grpc</className>
+    <className>com/google/cloud/automl/v1/*Grpc</className>
     <field>METHOD_*</field>
   </difference>
 </differences>

--- a/grpc-google-cloud-automl-v1/src/main/java/com/google/cloud/automl/v1/AutoMlGrpc.java
+++ b/grpc-google-cloud-automl-v1/src/main/java/com/google/cloud/automl/v1/AutoMlGrpc.java
@@ -39,7 +39,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/automl/v1/service.proto")
 public final class AutoMlGrpc {
 
@@ -48,26 +48,18 @@ public final class AutoMlGrpc {
   public static final String SERVICE_NAME = "google.cloud.automl.v1.AutoMl";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.CreateDatasetRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_DATASET = getCreateDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.CreateDatasetRequest, com.google.longrunning.Operation>
       getCreateDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateDataset",
+      requestType = com.google.cloud.automl.v1.CreateDatasetRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.CreateDatasetRequest, com.google.longrunning.Operation>
       getCreateDatasetMethod() {
-    return getCreateDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.CreateDatasetRequest, com.google.longrunning.Operation>
-      getCreateDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.CreateDatasetRequest, com.google.longrunning.Operation>
         getCreateDatasetMethod;
@@ -81,8 +73,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "CreateDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -98,26 +89,18 @@ public final class AutoMlGrpc {
     return getCreateDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetDatasetRequest, com.google.cloud.automl.v1.Dataset>
-      METHOD_GET_DATASET = getGetDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetDatasetRequest, com.google.cloud.automl.v1.Dataset>
       getGetDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetDataset",
+      requestType = com.google.cloud.automl.v1.GetDatasetRequest.class,
+      responseType = com.google.cloud.automl.v1.Dataset.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetDatasetRequest, com.google.cloud.automl.v1.Dataset>
       getGetDatasetMethod() {
-    return getGetDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetDatasetRequest, com.google.cloud.automl.v1.Dataset>
-      getGetDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.GetDatasetRequest, com.google.cloud.automl.v1.Dataset>
         getGetDatasetMethod;
@@ -131,8 +114,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.Dataset>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "GetDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -148,30 +130,20 @@ public final class AutoMlGrpc {
     return getGetDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListDatasetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListDatasetsRequest,
-          com.google.cloud.automl.v1.ListDatasetsResponse>
-      METHOD_LIST_DATASETS = getListDatasetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListDatasetsRequest,
           com.google.cloud.automl.v1.ListDatasetsResponse>
       getListDatasetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListDatasets",
+      requestType = com.google.cloud.automl.v1.ListDatasetsRequest.class,
+      responseType = com.google.cloud.automl.v1.ListDatasetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListDatasetsRequest,
           com.google.cloud.automl.v1.ListDatasetsResponse>
       getListDatasetsMethod() {
-    return getListDatasetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListDatasetsRequest,
-          com.google.cloud.automl.v1.ListDatasetsResponse>
-      getListDatasetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ListDatasetsRequest,
             com.google.cloud.automl.v1.ListDatasetsResponse>
@@ -186,8 +158,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.ListDatasetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "ListDatasets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListDatasets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -203,26 +174,18 @@ public final class AutoMlGrpc {
     return getListDatasetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UpdateDatasetRequest, com.google.cloud.automl.v1.Dataset>
-      METHOD_UPDATE_DATASET = getUpdateDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UpdateDatasetRequest, com.google.cloud.automl.v1.Dataset>
       getUpdateDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateDataset",
+      requestType = com.google.cloud.automl.v1.UpdateDatasetRequest.class,
+      responseType = com.google.cloud.automl.v1.Dataset.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UpdateDatasetRequest, com.google.cloud.automl.v1.Dataset>
       getUpdateDatasetMethod() {
-    return getUpdateDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UpdateDatasetRequest, com.google.cloud.automl.v1.Dataset>
-      getUpdateDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.UpdateDatasetRequest, com.google.cloud.automl.v1.Dataset>
         getUpdateDatasetMethod;
@@ -236,8 +199,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.Dataset>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "UpdateDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -253,26 +215,18 @@ public final class AutoMlGrpc {
     return getUpdateDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeleteDatasetRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_DATASET = getDeleteDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeleteDatasetRequest, com.google.longrunning.Operation>
       getDeleteDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteDataset",
+      requestType = com.google.cloud.automl.v1.DeleteDatasetRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeleteDatasetRequest, com.google.longrunning.Operation>
       getDeleteDatasetMethod() {
-    return getDeleteDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeleteDatasetRequest, com.google.longrunning.Operation>
-      getDeleteDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.DeleteDatasetRequest, com.google.longrunning.Operation>
         getDeleteDatasetMethod;
@@ -286,8 +240,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "DeleteDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -303,26 +256,18 @@ public final class AutoMlGrpc {
     return getDeleteDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportDataMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ImportDataRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_DATA = getImportDataMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ImportDataRequest, com.google.longrunning.Operation>
       getImportDataMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportData",
+      requestType = com.google.cloud.automl.v1.ImportDataRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ImportDataRequest, com.google.longrunning.Operation>
       getImportDataMethod() {
-    return getImportDataMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ImportDataRequest, com.google.longrunning.Operation>
-      getImportDataMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ImportDataRequest, com.google.longrunning.Operation>
         getImportDataMethod;
@@ -336,8 +281,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "ImportData"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportData"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -353,26 +297,18 @@ public final class AutoMlGrpc {
     return getImportDataMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportDataMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ExportDataRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_DATA = getExportDataMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ExportDataRequest, com.google.longrunning.Operation>
       getExportDataMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportData",
+      requestType = com.google.cloud.automl.v1.ExportDataRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ExportDataRequest, com.google.longrunning.Operation>
       getExportDataMethod() {
-    return getExportDataMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ExportDataRequest, com.google.longrunning.Operation>
-      getExportDataMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ExportDataRequest, com.google.longrunning.Operation>
         getExportDataMethod;
@@ -386,8 +322,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "ExportData"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportData"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -403,30 +338,20 @@ public final class AutoMlGrpc {
     return getExportDataMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAnnotationSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetAnnotationSpecRequest,
-          com.google.cloud.automl.v1.AnnotationSpec>
-      METHOD_GET_ANNOTATION_SPEC = getGetAnnotationSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetAnnotationSpecRequest,
           com.google.cloud.automl.v1.AnnotationSpec>
       getGetAnnotationSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAnnotationSpec",
+      requestType = com.google.cloud.automl.v1.GetAnnotationSpecRequest.class,
+      responseType = com.google.cloud.automl.v1.AnnotationSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetAnnotationSpecRequest,
           com.google.cloud.automl.v1.AnnotationSpec>
       getGetAnnotationSpecMethod() {
-    return getGetAnnotationSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetAnnotationSpecRequest,
-          com.google.cloud.automl.v1.AnnotationSpec>
-      getGetAnnotationSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.GetAnnotationSpecRequest,
             com.google.cloud.automl.v1.AnnotationSpec>
@@ -441,9 +366,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.AnnotationSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1.AutoMl", "GetAnnotationSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetAnnotationSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -460,26 +383,18 @@ public final class AutoMlGrpc {
     return getGetAnnotationSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.CreateModelRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_MODEL = getCreateModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.CreateModelRequest, com.google.longrunning.Operation>
       getCreateModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateModel",
+      requestType = com.google.cloud.automl.v1.CreateModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.CreateModelRequest, com.google.longrunning.Operation>
       getCreateModelMethod() {
-    return getCreateModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.CreateModelRequest, com.google.longrunning.Operation>
-      getCreateModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.CreateModelRequest, com.google.longrunning.Operation>
         getCreateModelMethod;
@@ -493,8 +408,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "CreateModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -510,26 +424,18 @@ public final class AutoMlGrpc {
     return getCreateModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>
-      METHOD_GET_MODEL = getGetModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>
       getGetModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetModel",
+      requestType = com.google.cloud.automl.v1.GetModelRequest.class,
+      responseType = com.google.cloud.automl.v1.Model.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>
       getGetModelMethod() {
-    return getGetModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>
-      getGetModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>
         getGetModelMethod;
@@ -543,8 +449,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.Model>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "GetModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -560,30 +465,20 @@ public final class AutoMlGrpc {
     return getGetModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListModelsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListModelsRequest,
-          com.google.cloud.automl.v1.ListModelsResponse>
-      METHOD_LIST_MODELS = getListModelsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListModelsRequest,
           com.google.cloud.automl.v1.ListModelsResponse>
       getListModelsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListModels",
+      requestType = com.google.cloud.automl.v1.ListModelsRequest.class,
+      responseType = com.google.cloud.automl.v1.ListModelsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListModelsRequest,
           com.google.cloud.automl.v1.ListModelsResponse>
       getListModelsMethod() {
-    return getListModelsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListModelsRequest,
-          com.google.cloud.automl.v1.ListModelsResponse>
-      getListModelsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ListModelsRequest,
             com.google.cloud.automl.v1.ListModelsResponse>
@@ -598,8 +493,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.ListModelsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "ListModels"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListModels"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -615,26 +509,18 @@ public final class AutoMlGrpc {
     return getListModelsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeleteModelRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_MODEL = getDeleteModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeleteModelRequest, com.google.longrunning.Operation>
       getDeleteModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteModel",
+      requestType = com.google.cloud.automl.v1.DeleteModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeleteModelRequest, com.google.longrunning.Operation>
       getDeleteModelMethod() {
-    return getDeleteModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeleteModelRequest, com.google.longrunning.Operation>
-      getDeleteModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.DeleteModelRequest, com.google.longrunning.Operation>
         getDeleteModelMethod;
@@ -648,8 +534,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "DeleteModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -665,26 +550,18 @@ public final class AutoMlGrpc {
     return getDeleteModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UpdateModelRequest, com.google.cloud.automl.v1.Model>
-      METHOD_UPDATE_MODEL = getUpdateModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UpdateModelRequest, com.google.cloud.automl.v1.Model>
       getUpdateModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateModel",
+      requestType = com.google.cloud.automl.v1.UpdateModelRequest.class,
+      responseType = com.google.cloud.automl.v1.Model.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UpdateModelRequest, com.google.cloud.automl.v1.Model>
       getUpdateModelMethod() {
-    return getUpdateModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UpdateModelRequest, com.google.cloud.automl.v1.Model>
-      getUpdateModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.UpdateModelRequest, com.google.cloud.automl.v1.Model>
         getUpdateModelMethod;
@@ -698,8 +575,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.Model>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "UpdateModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -715,26 +591,18 @@ public final class AutoMlGrpc {
     return getUpdateModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeployModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeployModelRequest, com.google.longrunning.Operation>
-      METHOD_DEPLOY_MODEL = getDeployModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeployModelRequest, com.google.longrunning.Operation>
       getDeployModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeployModel",
+      requestType = com.google.cloud.automl.v1.DeployModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.DeployModelRequest, com.google.longrunning.Operation>
       getDeployModelMethod() {
-    return getDeployModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.DeployModelRequest, com.google.longrunning.Operation>
-      getDeployModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.DeployModelRequest, com.google.longrunning.Operation>
         getDeployModelMethod;
@@ -748,8 +616,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "DeployModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeployModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -765,26 +632,18 @@ public final class AutoMlGrpc {
     return getDeployModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUndeployModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UndeployModelRequest, com.google.longrunning.Operation>
-      METHOD_UNDEPLOY_MODEL = getUndeployModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UndeployModelRequest, com.google.longrunning.Operation>
       getUndeployModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UndeployModel",
+      requestType = com.google.cloud.automl.v1.UndeployModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.UndeployModelRequest, com.google.longrunning.Operation>
       getUndeployModelMethod() {
-    return getUndeployModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.UndeployModelRequest, com.google.longrunning.Operation>
-      getUndeployModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.UndeployModelRequest, com.google.longrunning.Operation>
         getUndeployModelMethod;
@@ -798,8 +657,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "UndeployModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UndeployModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -815,26 +673,18 @@ public final class AutoMlGrpc {
     return getUndeployModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ExportModelRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_MODEL = getExportModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ExportModelRequest, com.google.longrunning.Operation>
       getExportModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportModel",
+      requestType = com.google.cloud.automl.v1.ExportModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ExportModelRequest, com.google.longrunning.Operation>
       getExportModelMethod() {
-    return getExportModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ExportModelRequest, com.google.longrunning.Operation>
-      getExportModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ExportModelRequest, com.google.longrunning.Operation>
         getExportModelMethod;
@@ -848,8 +698,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1.AutoMl", "ExportModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -865,30 +714,20 @@ public final class AutoMlGrpc {
     return getExportModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetModelEvaluationMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetModelEvaluationRequest,
-          com.google.cloud.automl.v1.ModelEvaluation>
-      METHOD_GET_MODEL_EVALUATION = getGetModelEvaluationMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetModelEvaluationRequest,
           com.google.cloud.automl.v1.ModelEvaluation>
       getGetModelEvaluationMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetModelEvaluation",
+      requestType = com.google.cloud.automl.v1.GetModelEvaluationRequest.class,
+      responseType = com.google.cloud.automl.v1.ModelEvaluation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.GetModelEvaluationRequest,
           com.google.cloud.automl.v1.ModelEvaluation>
       getGetModelEvaluationMethod() {
-    return getGetModelEvaluationMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.GetModelEvaluationRequest,
-          com.google.cloud.automl.v1.ModelEvaluation>
-      getGetModelEvaluationMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.GetModelEvaluationRequest,
             com.google.cloud.automl.v1.ModelEvaluation>
@@ -903,9 +742,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1.ModelEvaluation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1.AutoMl", "GetModelEvaluation"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetModelEvaluation"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -922,30 +759,20 @@ public final class AutoMlGrpc {
     return getGetModelEvaluationMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListModelEvaluationsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListModelEvaluationsRequest,
-          com.google.cloud.automl.v1.ListModelEvaluationsResponse>
-      METHOD_LIST_MODEL_EVALUATIONS = getListModelEvaluationsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListModelEvaluationsRequest,
           com.google.cloud.automl.v1.ListModelEvaluationsResponse>
       getListModelEvaluationsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListModelEvaluations",
+      requestType = com.google.cloud.automl.v1.ListModelEvaluationsRequest.class,
+      responseType = com.google.cloud.automl.v1.ListModelEvaluationsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.ListModelEvaluationsRequest,
           com.google.cloud.automl.v1.ListModelEvaluationsResponse>
       getListModelEvaluationsMethod() {
-    return getListModelEvaluationsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.ListModelEvaluationsRequest,
-          com.google.cloud.automl.v1.ListModelEvaluationsResponse>
-      getListModelEvaluationsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.ListModelEvaluationsRequest,
             com.google.cloud.automl.v1.ListModelEvaluationsResponse>
@@ -961,8 +788,7 @@ public final class AutoMlGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1.AutoMl", "ListModelEvaluations"))
+                          generateFullMethodName(SERVICE_NAME, "ListModelEvaluations"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1026,7 +852,7 @@ public final class AutoMlGrpc {
     public void createDataset(
         com.google.cloud.automl.v1.CreateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1039,7 +865,7 @@ public final class AutoMlGrpc {
     public void getDataset(
         com.google.cloud.automl.v1.GetDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Dataset> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1053,7 +879,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ListDatasetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListDatasetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListDatasetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListDatasetsMethod(), responseObserver);
     }
 
     /**
@@ -1066,7 +892,7 @@ public final class AutoMlGrpc {
     public void updateDataset(
         com.google.cloud.automl.v1.UpdateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Dataset> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1083,7 +909,7 @@ public final class AutoMlGrpc {
     public void deleteDataset(
         com.google.cloud.automl.v1.DeleteDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1103,7 +929,7 @@ public final class AutoMlGrpc {
     public void importData(
         com.google.cloud.automl.v1.ImportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportDataMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportDataMethod(), responseObserver);
     }
 
     /**
@@ -1118,7 +944,7 @@ public final class AutoMlGrpc {
     public void exportData(
         com.google.cloud.automl.v1.ExportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportDataMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportDataMethod(), responseObserver);
     }
 
     /**
@@ -1131,7 +957,7 @@ public final class AutoMlGrpc {
     public void getAnnotationSpec(
         com.google.cloud.automl.v1.GetAnnotationSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.AnnotationSpec> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAnnotationSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAnnotationSpecMethod(), responseObserver);
     }
 
     /**
@@ -1148,7 +974,7 @@ public final class AutoMlGrpc {
     public void createModel(
         com.google.cloud.automl.v1.CreateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateModelMethod(), responseObserver);
     }
 
     /**
@@ -1161,7 +987,7 @@ public final class AutoMlGrpc {
     public void getModel(
         com.google.cloud.automl.v1.GetModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Model> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetModelMethod(), responseObserver);
     }
 
     /**
@@ -1175,7 +1001,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ListModelsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListModelsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListModelsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListModelsMethod(), responseObserver);
     }
 
     /**
@@ -1192,7 +1018,7 @@ public final class AutoMlGrpc {
     public void deleteModel(
         com.google.cloud.automl.v1.DeleteModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteModelMethod(), responseObserver);
     }
 
     /**
@@ -1205,7 +1031,7 @@ public final class AutoMlGrpc {
     public void updateModel(
         com.google.cloud.automl.v1.UpdateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Model> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateModelMethod(), responseObserver);
     }
 
     /**
@@ -1226,7 +1052,7 @@ public final class AutoMlGrpc {
     public void deployModel(
         com.google.cloud.automl.v1.DeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeployModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeployModelMethod(), responseObserver);
     }
 
     /**
@@ -1243,7 +1069,7 @@ public final class AutoMlGrpc {
     public void undeployModel(
         com.google.cloud.automl.v1.UndeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUndeployModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUndeployModelMethod(), responseObserver);
     }
 
     /**
@@ -1261,7 +1087,7 @@ public final class AutoMlGrpc {
     public void exportModel(
         com.google.cloud.automl.v1.ExportModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportModelMethod(), responseObserver);
     }
 
     /**
@@ -1274,7 +1100,7 @@ public final class AutoMlGrpc {
     public void getModelEvaluation(
         com.google.cloud.automl.v1.GetModelEvaluationRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ModelEvaluation> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetModelEvaluationMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetModelEvaluationMethod(), responseObserver);
     }
 
     /**
@@ -1288,119 +1114,119 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ListModelEvaluationsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListModelEvaluationsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListModelEvaluationsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListModelEvaluationsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateDatasetMethodHelper(),
+              getCreateDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.CreateDatasetRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_DATASET)))
           .addMethod(
-              getGetDatasetMethodHelper(),
+              getGetDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.GetDatasetRequest,
                       com.google.cloud.automl.v1.Dataset>(this, METHODID_GET_DATASET)))
           .addMethod(
-              getListDatasetsMethodHelper(),
+              getListDatasetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ListDatasetsRequest,
                       com.google.cloud.automl.v1.ListDatasetsResponse>(
                       this, METHODID_LIST_DATASETS)))
           .addMethod(
-              getUpdateDatasetMethodHelper(),
+              getUpdateDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.UpdateDatasetRequest,
                       com.google.cloud.automl.v1.Dataset>(this, METHODID_UPDATE_DATASET)))
           .addMethod(
-              getDeleteDatasetMethodHelper(),
+              getDeleteDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.DeleteDatasetRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_DATASET)))
           .addMethod(
-              getImportDataMethodHelper(),
+              getImportDataMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ImportDataRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_DATA)))
           .addMethod(
-              getExportDataMethodHelper(),
+              getExportDataMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ExportDataRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_DATA)))
           .addMethod(
-              getGetAnnotationSpecMethodHelper(),
+              getGetAnnotationSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.GetAnnotationSpecRequest,
                       com.google.cloud.automl.v1.AnnotationSpec>(
                       this, METHODID_GET_ANNOTATION_SPEC)))
           .addMethod(
-              getCreateModelMethodHelper(),
+              getCreateModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.CreateModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_MODEL)))
           .addMethod(
-              getGetModelMethodHelper(),
+              getGetModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.GetModelRequest, com.google.cloud.automl.v1.Model>(
                       this, METHODID_GET_MODEL)))
           .addMethod(
-              getListModelsMethodHelper(),
+              getListModelsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ListModelsRequest,
                       com.google.cloud.automl.v1.ListModelsResponse>(this, METHODID_LIST_MODELS)))
           .addMethod(
-              getDeleteModelMethodHelper(),
+              getDeleteModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.DeleteModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_MODEL)))
           .addMethod(
-              getUpdateModelMethodHelper(),
+              getUpdateModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.UpdateModelRequest,
                       com.google.cloud.automl.v1.Model>(this, METHODID_UPDATE_MODEL)))
           .addMethod(
-              getDeployModelMethodHelper(),
+              getDeployModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.DeployModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_DEPLOY_MODEL)))
           .addMethod(
-              getUndeployModelMethodHelper(),
+              getUndeployModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.UndeployModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_UNDEPLOY_MODEL)))
           .addMethod(
-              getExportModelMethodHelper(),
+              getExportModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ExportModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_MODEL)))
           .addMethod(
-              getGetModelEvaluationMethodHelper(),
+              getGetModelEvaluationMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.GetModelEvaluationRequest,
                       com.google.cloud.automl.v1.ModelEvaluation>(
                       this, METHODID_GET_MODEL_EVALUATION)))
           .addMethod(
-              getListModelEvaluationsMethodHelper(),
+              getListModelEvaluationsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.ListModelEvaluationsRequest,
@@ -1451,7 +1277,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.CreateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1467,9 +1293,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.GetDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Dataset> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetDatasetMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetDatasetMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1484,7 +1308,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListDatasetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListDatasetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListDatasetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1500,7 +1324,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.UpdateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Dataset> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1520,7 +1344,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.DeleteDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1543,9 +1367,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ImportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportDataMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getImportDataMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1561,9 +1383,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ExportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportDataMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getExportDataMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1577,7 +1397,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.GetAnnotationSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.AnnotationSpec> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAnnotationSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetAnnotationSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1597,7 +1417,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.CreateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1613,9 +1433,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.GetModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Model> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetModelMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetModelMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1630,9 +1448,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListModelsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListModelsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListModelsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -1650,7 +1466,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.DeleteModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1666,7 +1482,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.UpdateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.Model> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1690,7 +1506,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.DeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeployModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeployModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1710,7 +1526,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.UndeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUndeployModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUndeployModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1731,7 +1547,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.ExportModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1747,7 +1563,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1.GetModelEvaluationRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ModelEvaluation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetModelEvaluationMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetModelEvaluationMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1764,7 +1580,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.ListModelEvaluationsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListModelEvaluationsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListModelEvaluationsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1810,8 +1626,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation createDataset(
         com.google.cloud.automl.v1.CreateDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1823,8 +1638,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.Dataset getDataset(
         com.google.cloud.automl.v1.GetDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1836,8 +1650,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.ListDatasetsResponse listDatasets(
         com.google.cloud.automl.v1.ListDatasetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListDatasetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListDatasetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1849,8 +1662,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.Dataset updateDataset(
         com.google.cloud.automl.v1.UpdateDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1866,8 +1678,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deleteDataset(
         com.google.cloud.automl.v1.DeleteDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1886,8 +1697,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation importData(
         com.google.cloud.automl.v1.ImportDataRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportDataMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportDataMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1901,8 +1711,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation exportData(
         com.google.cloud.automl.v1.ExportDataRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportDataMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportDataMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1915,7 +1724,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1.AnnotationSpec getAnnotationSpec(
         com.google.cloud.automl.v1.GetAnnotationSpecRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetAnnotationSpecMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetAnnotationSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1931,8 +1740,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation createModel(
         com.google.cloud.automl.v1.CreateModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1944,7 +1752,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.Model getModel(
         com.google.cloud.automl.v1.GetModelRequest request) {
-      return blockingUnaryCall(getChannel(), getGetModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1956,8 +1764,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.ListModelsResponse listModels(
         com.google.cloud.automl.v1.ListModelsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListModelsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListModelsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1973,8 +1780,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deleteModel(
         com.google.cloud.automl.v1.DeleteModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1986,8 +1792,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1.Model updateModel(
         com.google.cloud.automl.v1.UpdateModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2007,8 +1812,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deployModel(
         com.google.cloud.automl.v1.DeployModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeployModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeployModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2024,8 +1828,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation undeployModel(
         com.google.cloud.automl.v1.UndeployModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUndeployModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUndeployModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2042,8 +1845,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation exportModel(
         com.google.cloud.automl.v1.ExportModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2056,7 +1858,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1.ModelEvaluation getModelEvaluation(
         com.google.cloud.automl.v1.GetModelEvaluationRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetModelEvaluationMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetModelEvaluationMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2069,7 +1871,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1.ListModelEvaluationsResponse listModelEvaluations(
         com.google.cloud.automl.v1.ListModelEvaluationsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListModelEvaluationsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListModelEvaluationsMethod(), getCallOptions(), request);
     }
   }
 
@@ -2113,7 +1915,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createDataset(com.google.cloud.automl.v1.CreateDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2126,7 +1928,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.automl.v1.Dataset>
         getDataset(com.google.cloud.automl.v1.GetDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2140,7 +1942,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1.ListDatasetsResponse>
         listDatasets(com.google.cloud.automl.v1.ListDatasetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListDatasetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListDatasetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2153,7 +1955,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.automl.v1.Dataset>
         updateDataset(com.google.cloud.automl.v1.UpdateDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2170,7 +1972,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteDataset(com.google.cloud.automl.v1.DeleteDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2190,7 +1992,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importData(com.google.cloud.automl.v1.ImportDataRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportDataMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportDataMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2205,7 +2007,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportData(com.google.cloud.automl.v1.ExportDataRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportDataMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportDataMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2219,7 +2021,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1.AnnotationSpec>
         getAnnotationSpec(com.google.cloud.automl.v1.GetAnnotationSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetAnnotationSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetAnnotationSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2236,7 +2038,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createModel(com.google.cloud.automl.v1.CreateModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2248,8 +2050,7 @@ public final class AutoMlGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.automl.v1.Model>
         getModel(com.google.cloud.automl.v1.GetModelRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetModelMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2263,7 +2064,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1.ListModelsResponse>
         listModels(com.google.cloud.automl.v1.ListModelsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListModelsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListModelsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2280,7 +2081,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteModel(com.google.cloud.automl.v1.DeleteModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2293,7 +2094,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.automl.v1.Model>
         updateModel(com.google.cloud.automl.v1.UpdateModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2314,7 +2115,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deployModel(com.google.cloud.automl.v1.DeployModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeployModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeployModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2331,7 +2132,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         undeployModel(com.google.cloud.automl.v1.UndeployModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUndeployModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUndeployModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2349,7 +2150,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportModel(com.google.cloud.automl.v1.ExportModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2363,7 +2164,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1.ModelEvaluation>
         getModelEvaluation(com.google.cloud.automl.v1.GetModelEvaluationRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetModelEvaluationMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetModelEvaluationMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2377,7 +2178,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1.ListModelEvaluationsResponse>
         listModelEvaluations(com.google.cloud.automl.v1.ListModelEvaluationsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListModelEvaluationsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListModelEvaluationsMethod(), getCallOptions()), request);
     }
   }
 
@@ -2574,24 +2375,24 @@ public final class AutoMlGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AutoMlFileDescriptorSupplier())
-                      .addMethod(getCreateDatasetMethodHelper())
-                      .addMethod(getGetDatasetMethodHelper())
-                      .addMethod(getListDatasetsMethodHelper())
-                      .addMethod(getUpdateDatasetMethodHelper())
-                      .addMethod(getDeleteDatasetMethodHelper())
-                      .addMethod(getImportDataMethodHelper())
-                      .addMethod(getExportDataMethodHelper())
-                      .addMethod(getGetAnnotationSpecMethodHelper())
-                      .addMethod(getCreateModelMethodHelper())
-                      .addMethod(getGetModelMethodHelper())
-                      .addMethod(getListModelsMethodHelper())
-                      .addMethod(getDeleteModelMethodHelper())
-                      .addMethod(getUpdateModelMethodHelper())
-                      .addMethod(getDeployModelMethodHelper())
-                      .addMethod(getUndeployModelMethodHelper())
-                      .addMethod(getExportModelMethodHelper())
-                      .addMethod(getGetModelEvaluationMethodHelper())
-                      .addMethod(getListModelEvaluationsMethodHelper())
+                      .addMethod(getCreateDatasetMethod())
+                      .addMethod(getGetDatasetMethod())
+                      .addMethod(getListDatasetsMethod())
+                      .addMethod(getUpdateDatasetMethod())
+                      .addMethod(getDeleteDatasetMethod())
+                      .addMethod(getImportDataMethod())
+                      .addMethod(getExportDataMethod())
+                      .addMethod(getGetAnnotationSpecMethod())
+                      .addMethod(getCreateModelMethod())
+                      .addMethod(getGetModelMethod())
+                      .addMethod(getListModelsMethod())
+                      .addMethod(getDeleteModelMethod())
+                      .addMethod(getUpdateModelMethod())
+                      .addMethod(getDeployModelMethod())
+                      .addMethod(getUndeployModelMethod())
+                      .addMethod(getExportModelMethod())
+                      .addMethod(getGetModelEvaluationMethod())
+                      .addMethod(getListModelEvaluationsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-automl-v1/src/main/java/com/google/cloud/automl/v1/PredictionServiceGrpc.java
+++ b/grpc-google-cloud-automl-v1/src/main/java/com/google/cloud/automl/v1/PredictionServiceGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/automl/v1/prediction_service.proto")
 public final class PredictionServiceGrpc {
 
@@ -41,26 +41,18 @@ public final class PredictionServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.automl.v1.PredictionService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getPredictMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.PredictRequest, com.google.cloud.automl.v1.PredictResponse>
-      METHOD_PREDICT = getPredictMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.PredictRequest, com.google.cloud.automl.v1.PredictResponse>
       getPredictMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "Predict",
+      requestType = com.google.cloud.automl.v1.PredictRequest.class,
+      responseType = com.google.cloud.automl.v1.PredictResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.PredictRequest, com.google.cloud.automl.v1.PredictResponse>
       getPredictMethod() {
-    return getPredictMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.PredictRequest, com.google.cloud.automl.v1.PredictResponse>
-      getPredictMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.PredictRequest, com.google.cloud.automl.v1.PredictResponse>
         getPredictMethod;
@@ -74,9 +66,7 @@ public final class PredictionServiceGrpc {
                           com.google.cloud.automl.v1.PredictResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1.PredictionService", "Predict"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Predict"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -92,26 +82,18 @@ public final class PredictionServiceGrpc {
     return getPredictMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchPredictMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.BatchPredictRequest, com.google.longrunning.Operation>
-      METHOD_BATCH_PREDICT = getBatchPredictMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.BatchPredictRequest, com.google.longrunning.Operation>
       getBatchPredictMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchPredict",
+      requestType = com.google.cloud.automl.v1.BatchPredictRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1.BatchPredictRequest, com.google.longrunning.Operation>
       getBatchPredictMethod() {
-    return getBatchPredictMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1.BatchPredictRequest, com.google.longrunning.Operation>
-      getBatchPredictMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1.BatchPredictRequest, com.google.longrunning.Operation>
         getBatchPredictMethod;
@@ -125,9 +107,7 @@ public final class PredictionServiceGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1.PredictionService", "BatchPredict"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchPredict"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -220,7 +200,7 @@ public final class PredictionServiceGrpc {
     public void predict(
         com.google.cloud.automl.v1.PredictRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.PredictResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getPredictMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getPredictMethod(), responseObserver);
     }
 
     /**
@@ -246,20 +226,20 @@ public final class PredictionServiceGrpc {
     public void batchPredict(
         com.google.cloud.automl.v1.BatchPredictRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchPredictMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchPredictMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getPredictMethodHelper(),
+              getPredictMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.PredictRequest,
                       com.google.cloud.automl.v1.PredictResponse>(this, METHODID_PREDICT)))
           .addMethod(
-              getBatchPredictMethodHelper(),
+              getBatchPredictMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1.BatchPredictRequest,
@@ -342,9 +322,7 @@ public final class PredictionServiceGrpc {
         com.google.cloud.automl.v1.PredictRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1.PredictResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getPredictMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getPredictMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -371,7 +349,7 @@ public final class PredictionServiceGrpc {
         com.google.cloud.automl.v1.BatchPredictRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchPredictMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchPredictMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -450,7 +428,7 @@ public final class PredictionServiceGrpc {
      */
     public com.google.cloud.automl.v1.PredictResponse predict(
         com.google.cloud.automl.v1.PredictRequest request) {
-      return blockingUnaryCall(getChannel(), getPredictMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getPredictMethod(), getCallOptions(), request);
     }
 
     /**
@@ -475,8 +453,7 @@ public final class PredictionServiceGrpc {
      */
     public com.google.longrunning.Operation batchPredict(
         com.google.cloud.automl.v1.BatchPredictRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getBatchPredictMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getBatchPredictMethod(), getCallOptions(), request);
     }
   }
 
@@ -553,8 +530,7 @@ public final class PredictionServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.automl.v1.PredictResponse>
         predict(com.google.cloud.automl.v1.PredictRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getPredictMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getPredictMethod(), getCallOptions()), request);
     }
 
     /**
@@ -580,7 +556,7 @@ public final class PredictionServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchPredict(com.google.cloud.automl.v1.BatchPredictRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchPredictMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchPredictMethod(), getCallOptions()), request);
     }
   }
 
@@ -679,8 +655,8 @@ public final class PredictionServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new PredictionServiceFileDescriptorSupplier())
-                      .addMethod(getPredictMethodHelper())
-                      .addMethod(getBatchPredictMethodHelper())
+                      .addMethod(getPredictMethod())
+                      .addMethod(getBatchPredictMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-automl-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-automl-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.0 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/automl/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-automl-v1beta1/src/main/java/com/google/cloud/automl/v1beta1/AutoMlGrpc.java
+++ b/grpc-google-cloud-automl-v1beta1/src/main/java/com/google/cloud/automl/v1beta1/AutoMlGrpc.java
@@ -39,7 +39,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/automl/v1beta1/service.proto")
 public final class AutoMlGrpc {
 
@@ -48,30 +48,20 @@ public final class AutoMlGrpc {
   public static final String SERVICE_NAME = "google.cloud.automl.v1beta1.AutoMl";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.CreateDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      METHOD_CREATE_DATASET = getCreateDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.CreateDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getCreateDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateDataset",
+      requestType = com.google.cloud.automl.v1beta1.CreateDatasetRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.Dataset.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.CreateDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getCreateDatasetMethod() {
-    return getCreateDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.CreateDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      getCreateDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.CreateDatasetRequest,
             com.google.cloud.automl.v1beta1.Dataset>
@@ -86,9 +76,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.Dataset>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "CreateDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -105,30 +93,20 @@ public final class AutoMlGrpc {
     return getCreateDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      METHOD_GET_DATASET = getGetDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getGetDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetDataset",
+      requestType = com.google.cloud.automl.v1beta1.GetDatasetRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.Dataset.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getGetDatasetMethod() {
-    return getGetDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      getGetDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetDatasetRequest,
             com.google.cloud.automl.v1beta1.Dataset>
@@ -143,9 +121,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.Dataset>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "GetDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -162,30 +138,20 @@ public final class AutoMlGrpc {
     return getGetDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListDatasetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListDatasetsRequest,
-          com.google.cloud.automl.v1beta1.ListDatasetsResponse>
-      METHOD_LIST_DATASETS = getListDatasetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListDatasetsRequest,
           com.google.cloud.automl.v1beta1.ListDatasetsResponse>
       getListDatasetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListDatasets",
+      requestType = com.google.cloud.automl.v1beta1.ListDatasetsRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ListDatasetsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListDatasetsRequest,
           com.google.cloud.automl.v1beta1.ListDatasetsResponse>
       getListDatasetsMethod() {
-    return getListDatasetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListDatasetsRequest,
-          com.google.cloud.automl.v1beta1.ListDatasetsResponse>
-      getListDatasetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ListDatasetsRequest,
             com.google.cloud.automl.v1beta1.ListDatasetsResponse>
@@ -200,9 +166,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ListDatasetsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ListDatasets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListDatasets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -220,30 +184,20 @@ public final class AutoMlGrpc {
     return getListDatasetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      METHOD_UPDATE_DATASET = getUpdateDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getUpdateDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateDataset",
+      requestType = com.google.cloud.automl.v1beta1.UpdateDatasetRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.Dataset.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
           com.google.cloud.automl.v1beta1.Dataset>
       getUpdateDatasetMethod() {
-    return getUpdateDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
-          com.google.cloud.automl.v1beta1.Dataset>
-      getUpdateDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
             com.google.cloud.automl.v1beta1.Dataset>
@@ -258,9 +212,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.Dataset>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "UpdateDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -277,26 +229,18 @@ public final class AutoMlGrpc {
     return getUpdateDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteDatasetMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeleteDatasetRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_DATASET = getDeleteDatasetMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeleteDatasetRequest, com.google.longrunning.Operation>
       getDeleteDatasetMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteDataset",
+      requestType = com.google.cloud.automl.v1beta1.DeleteDatasetRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeleteDatasetRequest, com.google.longrunning.Operation>
       getDeleteDatasetMethod() {
-    return getDeleteDatasetMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeleteDatasetRequest, com.google.longrunning.Operation>
-      getDeleteDatasetMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.DeleteDatasetRequest, com.google.longrunning.Operation>
         getDeleteDatasetMethod;
@@ -310,9 +254,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "DeleteDataset"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteDataset"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -329,26 +271,18 @@ public final class AutoMlGrpc {
     return getDeleteDatasetMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportDataMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ImportDataRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_DATA = getImportDataMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ImportDataRequest, com.google.longrunning.Operation>
       getImportDataMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportData",
+      requestType = com.google.cloud.automl.v1beta1.ImportDataRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ImportDataRequest, com.google.longrunning.Operation>
       getImportDataMethod() {
-    return getImportDataMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ImportDataRequest, com.google.longrunning.Operation>
-      getImportDataMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ImportDataRequest, com.google.longrunning.Operation>
         getImportDataMethod;
@@ -362,9 +296,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ImportData"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportData"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -381,26 +313,18 @@ public final class AutoMlGrpc {
     return getImportDataMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportDataMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportDataRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_DATA = getExportDataMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportDataRequest, com.google.longrunning.Operation>
       getExportDataMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportData",
+      requestType = com.google.cloud.automl.v1beta1.ExportDataRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportDataRequest, com.google.longrunning.Operation>
       getExportDataMethod() {
-    return getExportDataMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportDataRequest, com.google.longrunning.Operation>
-      getExportDataMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ExportDataRequest, com.google.longrunning.Operation>
         getExportDataMethod;
@@ -414,9 +338,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ExportData"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportData"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -433,30 +355,20 @@ public final class AutoMlGrpc {
     return getExportDataMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetAnnotationSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
-          com.google.cloud.automl.v1beta1.AnnotationSpec>
-      METHOD_GET_ANNOTATION_SPEC = getGetAnnotationSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
           com.google.cloud.automl.v1beta1.AnnotationSpec>
       getGetAnnotationSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetAnnotationSpec",
+      requestType = com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.AnnotationSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
           com.google.cloud.automl.v1beta1.AnnotationSpec>
       getGetAnnotationSpecMethod() {
-    return getGetAnnotationSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
-          com.google.cloud.automl.v1beta1.AnnotationSpec>
-      getGetAnnotationSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
             com.google.cloud.automl.v1beta1.AnnotationSpec>
@@ -471,9 +383,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.AnnotationSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "GetAnnotationSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetAnnotationSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -490,30 +400,20 @@ public final class AutoMlGrpc {
     return getGetAnnotationSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetTableSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetTableSpecRequest,
-          com.google.cloud.automl.v1beta1.TableSpec>
-      METHOD_GET_TABLE_SPEC = getGetTableSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetTableSpecRequest,
           com.google.cloud.automl.v1beta1.TableSpec>
       getGetTableSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetTableSpec",
+      requestType = com.google.cloud.automl.v1beta1.GetTableSpecRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.TableSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetTableSpecRequest,
           com.google.cloud.automl.v1beta1.TableSpec>
       getGetTableSpecMethod() {
-    return getGetTableSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetTableSpecRequest,
-          com.google.cloud.automl.v1beta1.TableSpec>
-      getGetTableSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetTableSpecRequest,
             com.google.cloud.automl.v1beta1.TableSpec>
@@ -528,9 +428,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.TableSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "GetTableSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetTableSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -547,30 +445,20 @@ public final class AutoMlGrpc {
     return getGetTableSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListTableSpecsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
-          com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
-      METHOD_LIST_TABLE_SPECS = getListTableSpecsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
           com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
       getListTableSpecsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListTableSpecs",
+      requestType = com.google.cloud.automl.v1beta1.ListTableSpecsRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ListTableSpecsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
           com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
       getListTableSpecsMethod() {
-    return getListTableSpecsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
-          com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
-      getListTableSpecsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
             com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
@@ -585,9 +473,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ListTableSpecs"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListTableSpecs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -605,30 +491,20 @@ public final class AutoMlGrpc {
     return getListTableSpecsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateTableSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
-          com.google.cloud.automl.v1beta1.TableSpec>
-      METHOD_UPDATE_TABLE_SPEC = getUpdateTableSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
           com.google.cloud.automl.v1beta1.TableSpec>
       getUpdateTableSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateTableSpec",
+      requestType = com.google.cloud.automl.v1beta1.UpdateTableSpecRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.TableSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
           com.google.cloud.automl.v1beta1.TableSpec>
       getUpdateTableSpecMethod() {
-    return getUpdateTableSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
-          com.google.cloud.automl.v1beta1.TableSpec>
-      getUpdateTableSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
             com.google.cloud.automl.v1beta1.TableSpec>
@@ -643,9 +519,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.TableSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "UpdateTableSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateTableSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -662,30 +536,20 @@ public final class AutoMlGrpc {
     return getUpdateTableSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetColumnSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
-          com.google.cloud.automl.v1beta1.ColumnSpec>
-      METHOD_GET_COLUMN_SPEC = getGetColumnSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
           com.google.cloud.automl.v1beta1.ColumnSpec>
       getGetColumnSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetColumnSpec",
+      requestType = com.google.cloud.automl.v1beta1.GetColumnSpecRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ColumnSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
           com.google.cloud.automl.v1beta1.ColumnSpec>
       getGetColumnSpecMethod() {
-    return getGetColumnSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
-          com.google.cloud.automl.v1beta1.ColumnSpec>
-      getGetColumnSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
             com.google.cloud.automl.v1beta1.ColumnSpec>
@@ -700,9 +564,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ColumnSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "GetColumnSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetColumnSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -719,30 +581,20 @@ public final class AutoMlGrpc {
     return getGetColumnSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListColumnSpecsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
-          com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
-      METHOD_LIST_COLUMN_SPECS = getListColumnSpecsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
           com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
       getListColumnSpecsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListColumnSpecs",
+      requestType = com.google.cloud.automl.v1beta1.ListColumnSpecsRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ListColumnSpecsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
           com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
       getListColumnSpecsMethod() {
-    return getListColumnSpecsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
-          com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
-      getListColumnSpecsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
             com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
@@ -757,9 +609,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ListColumnSpecs"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListColumnSpecs"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -777,30 +627,20 @@ public final class AutoMlGrpc {
     return getListColumnSpecsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateColumnSpecMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
-          com.google.cloud.automl.v1beta1.ColumnSpec>
-      METHOD_UPDATE_COLUMN_SPEC = getUpdateColumnSpecMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
           com.google.cloud.automl.v1beta1.ColumnSpec>
       getUpdateColumnSpecMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateColumnSpec",
+      requestType = com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ColumnSpec.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
           com.google.cloud.automl.v1beta1.ColumnSpec>
       getUpdateColumnSpecMethod() {
-    return getUpdateColumnSpecMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
-          com.google.cloud.automl.v1beta1.ColumnSpec>
-      getUpdateColumnSpecMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
             com.google.cloud.automl.v1beta1.ColumnSpec>
@@ -815,9 +655,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ColumnSpec>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "UpdateColumnSpec"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateColumnSpec"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -834,26 +672,18 @@ public final class AutoMlGrpc {
     return getUpdateColumnSpecMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.CreateModelRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_MODEL = getCreateModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.CreateModelRequest, com.google.longrunning.Operation>
       getCreateModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateModel",
+      requestType = com.google.cloud.automl.v1beta1.CreateModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.CreateModelRequest, com.google.longrunning.Operation>
       getCreateModelMethod() {
-    return getCreateModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.CreateModelRequest, com.google.longrunning.Operation>
-      getCreateModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.CreateModelRequest, com.google.longrunning.Operation>
         getCreateModelMethod;
@@ -867,9 +697,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "CreateModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -886,26 +714,18 @@ public final class AutoMlGrpc {
     return getCreateModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetModelRequest, com.google.cloud.automl.v1beta1.Model>
-      METHOD_GET_MODEL = getGetModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetModelRequest, com.google.cloud.automl.v1beta1.Model>
       getGetModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetModel",
+      requestType = com.google.cloud.automl.v1beta1.GetModelRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.Model.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetModelRequest, com.google.cloud.automl.v1beta1.Model>
       getGetModelMethod() {
-    return getGetModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetModelRequest, com.google.cloud.automl.v1beta1.Model>
-      getGetModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetModelRequest, com.google.cloud.automl.v1beta1.Model>
         getGetModelMethod;
@@ -919,8 +739,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.Model>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.automl.v1beta1.AutoMl", "GetModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -936,30 +755,20 @@ public final class AutoMlGrpc {
     return getGetModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListModelsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListModelsRequest,
-          com.google.cloud.automl.v1beta1.ListModelsResponse>
-      METHOD_LIST_MODELS = getListModelsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListModelsRequest,
           com.google.cloud.automl.v1beta1.ListModelsResponse>
       getListModelsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListModels",
+      requestType = com.google.cloud.automl.v1beta1.ListModelsRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ListModelsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListModelsRequest,
           com.google.cloud.automl.v1beta1.ListModelsResponse>
       getListModelsMethod() {
-    return getListModelsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListModelsRequest,
-          com.google.cloud.automl.v1beta1.ListModelsResponse>
-      getListModelsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ListModelsRequest,
             com.google.cloud.automl.v1beta1.ListModelsResponse>
@@ -974,9 +783,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ListModelsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ListModels"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListModels"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -994,26 +801,18 @@ public final class AutoMlGrpc {
     return getListModelsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeleteModelRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_MODEL = getDeleteModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeleteModelRequest, com.google.longrunning.Operation>
       getDeleteModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteModel",
+      requestType = com.google.cloud.automl.v1beta1.DeleteModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeleteModelRequest, com.google.longrunning.Operation>
       getDeleteModelMethod() {
-    return getDeleteModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeleteModelRequest, com.google.longrunning.Operation>
-      getDeleteModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.DeleteModelRequest, com.google.longrunning.Operation>
         getDeleteModelMethod;
@@ -1027,9 +826,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "DeleteModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1046,26 +843,18 @@ public final class AutoMlGrpc {
     return getDeleteModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeployModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeployModelRequest, com.google.longrunning.Operation>
-      METHOD_DEPLOY_MODEL = getDeployModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeployModelRequest, com.google.longrunning.Operation>
       getDeployModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeployModel",
+      requestType = com.google.cloud.automl.v1beta1.DeployModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.DeployModelRequest, com.google.longrunning.Operation>
       getDeployModelMethod() {
-    return getDeployModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.DeployModelRequest, com.google.longrunning.Operation>
-      getDeployModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.DeployModelRequest, com.google.longrunning.Operation>
         getDeployModelMethod;
@@ -1079,9 +868,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "DeployModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeployModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1098,26 +885,18 @@ public final class AutoMlGrpc {
     return getDeployModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUndeployModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UndeployModelRequest, com.google.longrunning.Operation>
-      METHOD_UNDEPLOY_MODEL = getUndeployModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UndeployModelRequest, com.google.longrunning.Operation>
       getUndeployModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UndeployModel",
+      requestType = com.google.cloud.automl.v1beta1.UndeployModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.UndeployModelRequest, com.google.longrunning.Operation>
       getUndeployModelMethod() {
-    return getUndeployModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.UndeployModelRequest, com.google.longrunning.Operation>
-      getUndeployModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.UndeployModelRequest, com.google.longrunning.Operation>
         getUndeployModelMethod;
@@ -1131,9 +910,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "UndeployModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UndeployModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1150,26 +927,18 @@ public final class AutoMlGrpc {
     return getUndeployModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportModelMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportModelRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_MODEL = getExportModelMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportModelRequest, com.google.longrunning.Operation>
       getExportModelMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportModel",
+      requestType = com.google.cloud.automl.v1beta1.ExportModelRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportModelRequest, com.google.longrunning.Operation>
       getExportModelMethod() {
-    return getExportModelMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportModelRequest, com.google.longrunning.Operation>
-      getExportModelMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ExportModelRequest, com.google.longrunning.Operation>
         getExportModelMethod;
@@ -1183,9 +952,7 @@ public final class AutoMlGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ExportModel"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportModel"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1202,30 +969,20 @@ public final class AutoMlGrpc {
     return getExportModelMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportEvaluatedExamplesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
-          com.google.longrunning.Operation>
-      METHOD_EXPORT_EVALUATED_EXAMPLES = getExportEvaluatedExamplesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
           com.google.longrunning.Operation>
       getExportEvaluatedExamplesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportEvaluatedExamples",
+      requestType = com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
           com.google.longrunning.Operation>
       getExportEvaluatedExamplesMethod() {
-    return getExportEvaluatedExamplesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
-          com.google.longrunning.Operation>
-      getExportEvaluatedExamplesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
             com.google.longrunning.Operation>
@@ -1242,8 +999,7 @@ public final class AutoMlGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ExportEvaluatedExamples"))
+                          generateFullMethodName(SERVICE_NAME, "ExportEvaluatedExamples"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1261,30 +1017,20 @@ public final class AutoMlGrpc {
     return getExportEvaluatedExamplesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetModelEvaluationMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
-          com.google.cloud.automl.v1beta1.ModelEvaluation>
-      METHOD_GET_MODEL_EVALUATION = getGetModelEvaluationMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
           com.google.cloud.automl.v1beta1.ModelEvaluation>
       getGetModelEvaluationMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetModelEvaluation",
+      requestType = com.google.cloud.automl.v1beta1.GetModelEvaluationRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ModelEvaluation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
           com.google.cloud.automl.v1beta1.ModelEvaluation>
       getGetModelEvaluationMethod() {
-    return getGetModelEvaluationMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
-          com.google.cloud.automl.v1beta1.ModelEvaluation>
-      getGetModelEvaluationMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
             com.google.cloud.automl.v1beta1.ModelEvaluation>
@@ -1299,9 +1045,7 @@ public final class AutoMlGrpc {
                           com.google.cloud.automl.v1beta1.ModelEvaluation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "GetModelEvaluation"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetModelEvaluation"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1318,30 +1062,20 @@ public final class AutoMlGrpc {
     return getGetModelEvaluationMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListModelEvaluationsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
-          com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
-      METHOD_LIST_MODEL_EVALUATIONS = getListModelEvaluationsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
           com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
       getListModelEvaluationsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListModelEvaluations",
+      requestType = com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
           com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
       getListModelEvaluationsMethod() {
-    return getListModelEvaluationsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
-          com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
-      getListModelEvaluationsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
             com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
@@ -1357,8 +1091,7 @@ public final class AutoMlGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.AutoMl", "ListModelEvaluations"))
+                          generateFullMethodName(SERVICE_NAME, "ListModelEvaluations"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -1422,7 +1155,7 @@ public final class AutoMlGrpc {
     public void createDataset(
         com.google.cloud.automl.v1beta1.CreateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1435,7 +1168,7 @@ public final class AutoMlGrpc {
     public void getDataset(
         com.google.cloud.automl.v1beta1.GetDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1449,7 +1182,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ListDatasetsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListDatasetsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListDatasetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListDatasetsMethod(), responseObserver);
     }
 
     /**
@@ -1462,7 +1195,7 @@ public final class AutoMlGrpc {
     public void updateDataset(
         com.google.cloud.automl.v1beta1.UpdateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1479,7 +1212,7 @@ public final class AutoMlGrpc {
     public void deleteDataset(
         com.google.cloud.automl.v1beta1.DeleteDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteDatasetMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteDatasetMethod(), responseObserver);
     }
 
     /**
@@ -1499,7 +1232,7 @@ public final class AutoMlGrpc {
     public void importData(
         com.google.cloud.automl.v1beta1.ImportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportDataMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportDataMethod(), responseObserver);
     }
 
     /**
@@ -1514,7 +1247,7 @@ public final class AutoMlGrpc {
     public void exportData(
         com.google.cloud.automl.v1beta1.ExportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportDataMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportDataMethod(), responseObserver);
     }
 
     /**
@@ -1528,7 +1261,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.AnnotationSpec>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetAnnotationSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetAnnotationSpecMethod(), responseObserver);
     }
 
     /**
@@ -1541,7 +1274,7 @@ public final class AutoMlGrpc {
     public void getTableSpec(
         com.google.cloud.automl.v1beta1.GetTableSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.TableSpec> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetTableSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetTableSpecMethod(), responseObserver);
     }
 
     /**
@@ -1555,7 +1288,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ListTableSpecsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListTableSpecsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListTableSpecsMethod(), responseObserver);
     }
 
     /**
@@ -1568,7 +1301,7 @@ public final class AutoMlGrpc {
     public void updateTableSpec(
         com.google.cloud.automl.v1beta1.UpdateTableSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.TableSpec> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateTableSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateTableSpecMethod(), responseObserver);
     }
 
     /**
@@ -1581,7 +1314,7 @@ public final class AutoMlGrpc {
     public void getColumnSpec(
         com.google.cloud.automl.v1beta1.GetColumnSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ColumnSpec> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetColumnSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetColumnSpecMethod(), responseObserver);
     }
 
     /**
@@ -1595,7 +1328,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ListColumnSpecsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListColumnSpecsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListColumnSpecsMethod(), responseObserver);
     }
 
     /**
@@ -1608,7 +1341,7 @@ public final class AutoMlGrpc {
     public void updateColumnSpec(
         com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ColumnSpec> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateColumnSpecMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateColumnSpecMethod(), responseObserver);
     }
 
     /**
@@ -1625,7 +1358,7 @@ public final class AutoMlGrpc {
     public void createModel(
         com.google.cloud.automl.v1beta1.CreateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateModelMethod(), responseObserver);
     }
 
     /**
@@ -1638,7 +1371,7 @@ public final class AutoMlGrpc {
     public void getModel(
         com.google.cloud.automl.v1beta1.GetModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Model> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetModelMethod(), responseObserver);
     }
 
     /**
@@ -1652,7 +1385,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ListModelsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListModelsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListModelsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListModelsMethod(), responseObserver);
     }
 
     /**
@@ -1669,7 +1402,7 @@ public final class AutoMlGrpc {
     public void deleteModel(
         com.google.cloud.automl.v1beta1.DeleteModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteModelMethod(), responseObserver);
     }
 
     /**
@@ -1690,7 +1423,7 @@ public final class AutoMlGrpc {
     public void deployModel(
         com.google.cloud.automl.v1beta1.DeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeployModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeployModelMethod(), responseObserver);
     }
 
     /**
@@ -1707,7 +1440,7 @@ public final class AutoMlGrpc {
     public void undeployModel(
         com.google.cloud.automl.v1beta1.UndeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUndeployModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUndeployModelMethod(), responseObserver);
     }
 
     /**
@@ -1725,7 +1458,7 @@ public final class AutoMlGrpc {
     public void exportModel(
         com.google.cloud.automl.v1beta1.ExportModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportModelMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportModelMethod(), responseObserver);
     }
 
     /**
@@ -1748,7 +1481,7 @@ public final class AutoMlGrpc {
     public void exportEvaluatedExamples(
         com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportEvaluatedExamplesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportEvaluatedExamplesMethod(), responseObserver);
     }
 
     /**
@@ -1762,7 +1495,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetModelEvaluationRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ModelEvaluation>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getGetModelEvaluationMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetModelEvaluationMethod(), responseObserver);
     }
 
     /**
@@ -1776,159 +1509,159 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListModelEvaluationsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListModelEvaluationsMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateDatasetMethodHelper(),
+              getCreateDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.CreateDatasetRequest,
                       com.google.cloud.automl.v1beta1.Dataset>(this, METHODID_CREATE_DATASET)))
           .addMethod(
-              getGetDatasetMethodHelper(),
+              getGetDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetDatasetRequest,
                       com.google.cloud.automl.v1beta1.Dataset>(this, METHODID_GET_DATASET)))
           .addMethod(
-              getListDatasetsMethodHelper(),
+              getListDatasetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ListDatasetsRequest,
                       com.google.cloud.automl.v1beta1.ListDatasetsResponse>(
                       this, METHODID_LIST_DATASETS)))
           .addMethod(
-              getUpdateDatasetMethodHelper(),
+              getUpdateDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.UpdateDatasetRequest,
                       com.google.cloud.automl.v1beta1.Dataset>(this, METHODID_UPDATE_DATASET)))
           .addMethod(
-              getDeleteDatasetMethodHelper(),
+              getDeleteDatasetMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.DeleteDatasetRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_DATASET)))
           .addMethod(
-              getImportDataMethodHelper(),
+              getImportDataMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ImportDataRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_DATA)))
           .addMethod(
-              getExportDataMethodHelper(),
+              getExportDataMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ExportDataRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_DATA)))
           .addMethod(
-              getGetAnnotationSpecMethodHelper(),
+              getGetAnnotationSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest,
                       com.google.cloud.automl.v1beta1.AnnotationSpec>(
                       this, METHODID_GET_ANNOTATION_SPEC)))
           .addMethod(
-              getGetTableSpecMethodHelper(),
+              getGetTableSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetTableSpecRequest,
                       com.google.cloud.automl.v1beta1.TableSpec>(this, METHODID_GET_TABLE_SPEC)))
           .addMethod(
-              getListTableSpecsMethodHelper(),
+              getListTableSpecsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ListTableSpecsRequest,
                       com.google.cloud.automl.v1beta1.ListTableSpecsResponse>(
                       this, METHODID_LIST_TABLE_SPECS)))
           .addMethod(
-              getUpdateTableSpecMethodHelper(),
+              getUpdateTableSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.UpdateTableSpecRequest,
                       com.google.cloud.automl.v1beta1.TableSpec>(this, METHODID_UPDATE_TABLE_SPEC)))
           .addMethod(
-              getGetColumnSpecMethodHelper(),
+              getGetColumnSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetColumnSpecRequest,
                       com.google.cloud.automl.v1beta1.ColumnSpec>(this, METHODID_GET_COLUMN_SPEC)))
           .addMethod(
-              getListColumnSpecsMethodHelper(),
+              getListColumnSpecsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ListColumnSpecsRequest,
                       com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>(
                       this, METHODID_LIST_COLUMN_SPECS)))
           .addMethod(
-              getUpdateColumnSpecMethodHelper(),
+              getUpdateColumnSpecMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest,
                       com.google.cloud.automl.v1beta1.ColumnSpec>(
                       this, METHODID_UPDATE_COLUMN_SPEC)))
           .addMethod(
-              getCreateModelMethodHelper(),
+              getCreateModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.CreateModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_MODEL)))
           .addMethod(
-              getGetModelMethodHelper(),
+              getGetModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetModelRequest,
                       com.google.cloud.automl.v1beta1.Model>(this, METHODID_GET_MODEL)))
           .addMethod(
-              getListModelsMethodHelper(),
+              getListModelsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ListModelsRequest,
                       com.google.cloud.automl.v1beta1.ListModelsResponse>(
                       this, METHODID_LIST_MODELS)))
           .addMethod(
-              getDeleteModelMethodHelper(),
+              getDeleteModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.DeleteModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_DELETE_MODEL)))
           .addMethod(
-              getDeployModelMethodHelper(),
+              getDeployModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.DeployModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_DEPLOY_MODEL)))
           .addMethod(
-              getUndeployModelMethodHelper(),
+              getUndeployModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.UndeployModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_UNDEPLOY_MODEL)))
           .addMethod(
-              getExportModelMethodHelper(),
+              getExportModelMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ExportModelRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_MODEL)))
           .addMethod(
-              getExportEvaluatedExamplesMethodHelper(),
+              getExportEvaluatedExamplesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_EVALUATED_EXAMPLES)))
           .addMethod(
-              getGetModelEvaluationMethodHelper(),
+              getGetModelEvaluationMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.GetModelEvaluationRequest,
                       com.google.cloud.automl.v1beta1.ModelEvaluation>(
                       this, METHODID_GET_MODEL_EVALUATION)))
           .addMethod(
-              getListModelEvaluationsMethodHelper(),
+              getListModelEvaluationsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest,
@@ -1979,7 +1712,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.CreateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1995,9 +1728,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetDatasetMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetDatasetMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2012,7 +1743,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListDatasetsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListDatasetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListDatasetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2028,7 +1759,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.UpdateDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Dataset> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2048,7 +1779,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.DeleteDatasetRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteDatasetMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteDatasetMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2071,9 +1802,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ImportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportDataMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getImportDataMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2089,9 +1818,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ExportDataRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportDataMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getExportDataMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2106,7 +1833,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.AnnotationSpec>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetAnnotationSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetAnnotationSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2122,7 +1849,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetTableSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.TableSpec> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetTableSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetTableSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2139,7 +1866,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListTableSpecsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListTableSpecsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2155,7 +1882,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.UpdateTableSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.TableSpec> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateTableSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateTableSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2171,7 +1898,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetColumnSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ColumnSpec> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetColumnSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetColumnSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2188,7 +1915,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListColumnSpecsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListColumnSpecsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2204,7 +1931,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ColumnSpec> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateColumnSpecMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateColumnSpecMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2224,7 +1951,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.CreateModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2240,9 +1967,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.GetModelRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.Model> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetModelMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetModelMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2257,9 +1982,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListModelsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListModelsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListModelsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -2277,7 +2000,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.DeleteModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2301,7 +2024,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.DeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeployModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeployModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2321,7 +2044,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.UndeployModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUndeployModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUndeployModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2342,7 +2065,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ExportModelRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportModelMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportModelMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2368,7 +2091,7 @@ public final class AutoMlGrpc {
         com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportEvaluatedExamplesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportEvaluatedExamplesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2385,7 +2108,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ModelEvaluation>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetModelEvaluationMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetModelEvaluationMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2402,7 +2125,7 @@ public final class AutoMlGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListModelEvaluationsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListModelEvaluationsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -2448,8 +2171,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.Dataset createDataset(
         com.google.cloud.automl.v1beta1.CreateDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2461,8 +2183,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.Dataset getDataset(
         com.google.cloud.automl.v1beta1.GetDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2474,8 +2195,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.ListDatasetsResponse listDatasets(
         com.google.cloud.automl.v1beta1.ListDatasetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListDatasetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListDatasetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2487,8 +2207,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.Dataset updateDataset(
         com.google.cloud.automl.v1beta1.UpdateDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2504,8 +2223,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deleteDataset(
         com.google.cloud.automl.v1beta1.DeleteDatasetRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteDatasetMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteDatasetMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2524,8 +2242,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation importData(
         com.google.cloud.automl.v1beta1.ImportDataRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportDataMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportDataMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2539,8 +2256,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation exportData(
         com.google.cloud.automl.v1beta1.ExportDataRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportDataMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportDataMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2553,7 +2269,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1beta1.AnnotationSpec getAnnotationSpec(
         com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetAnnotationSpecMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetAnnotationSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2565,8 +2281,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.TableSpec getTableSpec(
         com.google.cloud.automl.v1beta1.GetTableSpecRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetTableSpecMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetTableSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2578,8 +2293,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.ListTableSpecsResponse listTableSpecs(
         com.google.cloud.automl.v1beta1.ListTableSpecsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListTableSpecsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListTableSpecsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2591,8 +2305,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.TableSpec updateTableSpec(
         com.google.cloud.automl.v1beta1.UpdateTableSpecRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateTableSpecMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateTableSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2604,8 +2317,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.ColumnSpec getColumnSpec(
         com.google.cloud.automl.v1beta1.GetColumnSpecRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetColumnSpecMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetColumnSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2617,8 +2329,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.ListColumnSpecsResponse listColumnSpecs(
         com.google.cloud.automl.v1beta1.ListColumnSpecsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListColumnSpecsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListColumnSpecsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2631,7 +2342,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1beta1.ColumnSpec updateColumnSpec(
         com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest request) {
       return blockingUnaryCall(
-          getChannel(), getUpdateColumnSpecMethodHelper(), getCallOptions(), request);
+          getChannel(), getUpdateColumnSpecMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2647,8 +2358,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation createModel(
         com.google.cloud.automl.v1beta1.CreateModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2660,7 +2370,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.Model getModel(
         com.google.cloud.automl.v1beta1.GetModelRequest request) {
-      return blockingUnaryCall(getChannel(), getGetModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2672,8 +2382,7 @@ public final class AutoMlGrpc {
      */
     public com.google.cloud.automl.v1beta1.ListModelsResponse listModels(
         com.google.cloud.automl.v1beta1.ListModelsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListModelsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListModelsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2689,8 +2398,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deleteModel(
         com.google.cloud.automl.v1beta1.DeleteModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2710,8 +2418,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation deployModel(
         com.google.cloud.automl.v1beta1.DeployModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeployModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeployModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2727,8 +2434,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation undeployModel(
         com.google.cloud.automl.v1beta1.UndeployModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUndeployModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUndeployModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2745,8 +2451,7 @@ public final class AutoMlGrpc {
      */
     public com.google.longrunning.Operation exportModel(
         com.google.cloud.automl.v1beta1.ExportModelRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportModelMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportModelMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2769,7 +2474,7 @@ public final class AutoMlGrpc {
     public com.google.longrunning.Operation exportEvaluatedExamples(
         com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getExportEvaluatedExamplesMethodHelper(), getCallOptions(), request);
+          getChannel(), getExportEvaluatedExamplesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2782,7 +2487,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1beta1.ModelEvaluation getModelEvaluation(
         com.google.cloud.automl.v1beta1.GetModelEvaluationRequest request) {
       return blockingUnaryCall(
-          getChannel(), getGetModelEvaluationMethodHelper(), getCallOptions(), request);
+          getChannel(), getGetModelEvaluationMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2795,7 +2500,7 @@ public final class AutoMlGrpc {
     public com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse listModelEvaluations(
         com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest request) {
       return blockingUnaryCall(
-          getChannel(), getListModelEvaluationsMethodHelper(), getCallOptions(), request);
+          getChannel(), getListModelEvaluationsMethod(), getCallOptions(), request);
     }
   }
 
@@ -2840,7 +2545,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.Dataset>
         createDataset(com.google.cloud.automl.v1beta1.CreateDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2854,7 +2559,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.Dataset>
         getDataset(com.google.cloud.automl.v1beta1.GetDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2868,7 +2573,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ListDatasetsResponse>
         listDatasets(com.google.cloud.automl.v1beta1.ListDatasetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListDatasetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListDatasetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2882,7 +2587,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.Dataset>
         updateDataset(com.google.cloud.automl.v1beta1.UpdateDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2899,7 +2604,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteDataset(com.google.cloud.automl.v1beta1.DeleteDatasetRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteDatasetMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteDatasetMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2919,7 +2624,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importData(com.google.cloud.automl.v1beta1.ImportDataRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportDataMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportDataMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2934,7 +2639,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportData(com.google.cloud.automl.v1beta1.ExportDataRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportDataMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportDataMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2948,7 +2653,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.AnnotationSpec>
         getAnnotationSpec(com.google.cloud.automl.v1beta1.GetAnnotationSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetAnnotationSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetAnnotationSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2962,7 +2667,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.TableSpec>
         getTableSpec(com.google.cloud.automl.v1beta1.GetTableSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetTableSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetTableSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2976,7 +2681,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ListTableSpecsResponse>
         listTableSpecs(com.google.cloud.automl.v1beta1.ListTableSpecsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListTableSpecsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListTableSpecsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -2990,7 +2695,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.TableSpec>
         updateTableSpec(com.google.cloud.automl.v1beta1.UpdateTableSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateTableSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateTableSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3004,7 +2709,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ColumnSpec>
         getColumnSpec(com.google.cloud.automl.v1beta1.GetColumnSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetColumnSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetColumnSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3018,7 +2723,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ListColumnSpecsResponse>
         listColumnSpecs(com.google.cloud.automl.v1beta1.ListColumnSpecsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListColumnSpecsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListColumnSpecsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3032,7 +2737,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ColumnSpec>
         updateColumnSpec(com.google.cloud.automl.v1beta1.UpdateColumnSpecRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateColumnSpecMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateColumnSpecMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3049,7 +2754,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createModel(com.google.cloud.automl.v1beta1.CreateModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3061,8 +2766,7 @@ public final class AutoMlGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.automl.v1beta1.Model>
         getModel(com.google.cloud.automl.v1beta1.GetModelRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetModelMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3076,7 +2780,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ListModelsResponse>
         listModels(com.google.cloud.automl.v1beta1.ListModelsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListModelsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListModelsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3093,7 +2797,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteModel(com.google.cloud.automl.v1beta1.DeleteModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3114,7 +2818,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deployModel(com.google.cloud.automl.v1beta1.DeployModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeployModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeployModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3131,7 +2835,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         undeployModel(com.google.cloud.automl.v1beta1.UndeployModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUndeployModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUndeployModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3149,7 +2853,7 @@ public final class AutoMlGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportModel(com.google.cloud.automl.v1beta1.ExportModelRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportModelMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportModelMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3173,8 +2877,7 @@ public final class AutoMlGrpc {
         exportEvaluatedExamples(
             com.google.cloud.automl.v1beta1.ExportEvaluatedExamplesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportEvaluatedExamplesMethodHelper(), getCallOptions()),
-          request);
+          getChannel().newCall(getExportEvaluatedExamplesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3188,7 +2891,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ModelEvaluation>
         getModelEvaluation(com.google.cloud.automl.v1beta1.GetModelEvaluationRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetModelEvaluationMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetModelEvaluationMethod(), getCallOptions()), request);
     }
 
     /**
@@ -3202,7 +2905,7 @@ public final class AutoMlGrpc {
             com.google.cloud.automl.v1beta1.ListModelEvaluationsResponse>
         listModelEvaluations(com.google.cloud.automl.v1beta1.ListModelEvaluationsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListModelEvaluationsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListModelEvaluationsMethod(), getCallOptions()), request);
     }
   }
 
@@ -3446,30 +3149,30 @@ public final class AutoMlGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AutoMlFileDescriptorSupplier())
-                      .addMethod(getCreateDatasetMethodHelper())
-                      .addMethod(getGetDatasetMethodHelper())
-                      .addMethod(getListDatasetsMethodHelper())
-                      .addMethod(getUpdateDatasetMethodHelper())
-                      .addMethod(getDeleteDatasetMethodHelper())
-                      .addMethod(getImportDataMethodHelper())
-                      .addMethod(getExportDataMethodHelper())
-                      .addMethod(getGetAnnotationSpecMethodHelper())
-                      .addMethod(getGetTableSpecMethodHelper())
-                      .addMethod(getListTableSpecsMethodHelper())
-                      .addMethod(getUpdateTableSpecMethodHelper())
-                      .addMethod(getGetColumnSpecMethodHelper())
-                      .addMethod(getListColumnSpecsMethodHelper())
-                      .addMethod(getUpdateColumnSpecMethodHelper())
-                      .addMethod(getCreateModelMethodHelper())
-                      .addMethod(getGetModelMethodHelper())
-                      .addMethod(getListModelsMethodHelper())
-                      .addMethod(getDeleteModelMethodHelper())
-                      .addMethod(getDeployModelMethodHelper())
-                      .addMethod(getUndeployModelMethodHelper())
-                      .addMethod(getExportModelMethodHelper())
-                      .addMethod(getExportEvaluatedExamplesMethodHelper())
-                      .addMethod(getGetModelEvaluationMethodHelper())
-                      .addMethod(getListModelEvaluationsMethodHelper())
+                      .addMethod(getCreateDatasetMethod())
+                      .addMethod(getGetDatasetMethod())
+                      .addMethod(getListDatasetsMethod())
+                      .addMethod(getUpdateDatasetMethod())
+                      .addMethod(getDeleteDatasetMethod())
+                      .addMethod(getImportDataMethod())
+                      .addMethod(getExportDataMethod())
+                      .addMethod(getGetAnnotationSpecMethod())
+                      .addMethod(getGetTableSpecMethod())
+                      .addMethod(getListTableSpecsMethod())
+                      .addMethod(getUpdateTableSpecMethod())
+                      .addMethod(getGetColumnSpecMethod())
+                      .addMethod(getListColumnSpecsMethod())
+                      .addMethod(getUpdateColumnSpecMethod())
+                      .addMethod(getCreateModelMethod())
+                      .addMethod(getGetModelMethod())
+                      .addMethod(getListModelsMethod())
+                      .addMethod(getDeleteModelMethod())
+                      .addMethod(getDeployModelMethod())
+                      .addMethod(getUndeployModelMethod())
+                      .addMethod(getExportModelMethod())
+                      .addMethod(getExportEvaluatedExamplesMethod())
+                      .addMethod(getGetModelEvaluationMethod())
+                      .addMethod(getListModelEvaluationsMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-automl-v1beta1/src/main/java/com/google/cloud/automl/v1beta1/PredictionServiceGrpc.java
+++ b/grpc-google-cloud-automl-v1beta1/src/main/java/com/google/cloud/automl/v1beta1/PredictionServiceGrpc.java
@@ -32,7 +32,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/automl/v1beta1/prediction_service.proto")
 public final class PredictionServiceGrpc {
 
@@ -41,30 +41,20 @@ public final class PredictionServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.automl.v1beta1.PredictionService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getPredictMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.PredictRequest,
-          com.google.cloud.automl.v1beta1.PredictResponse>
-      METHOD_PREDICT = getPredictMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.PredictRequest,
           com.google.cloud.automl.v1beta1.PredictResponse>
       getPredictMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "Predict",
+      requestType = com.google.cloud.automl.v1beta1.PredictRequest.class,
+      responseType = com.google.cloud.automl.v1beta1.PredictResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.PredictRequest,
           com.google.cloud.automl.v1beta1.PredictResponse>
       getPredictMethod() {
-    return getPredictMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.PredictRequest,
-          com.google.cloud.automl.v1beta1.PredictResponse>
-      getPredictMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.PredictRequest,
             com.google.cloud.automl.v1beta1.PredictResponse>
@@ -79,9 +69,7 @@ public final class PredictionServiceGrpc {
                           com.google.cloud.automl.v1beta1.PredictResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.PredictionService", "Predict"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "Predict"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -97,26 +85,18 @@ public final class PredictionServiceGrpc {
     return getPredictMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchPredictMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.BatchPredictRequest, com.google.longrunning.Operation>
-      METHOD_BATCH_PREDICT = getBatchPredictMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.BatchPredictRequest, com.google.longrunning.Operation>
       getBatchPredictMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchPredict",
+      requestType = com.google.cloud.automl.v1beta1.BatchPredictRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.automl.v1beta1.BatchPredictRequest, com.google.longrunning.Operation>
       getBatchPredictMethod() {
-    return getBatchPredictMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.automl.v1beta1.BatchPredictRequest, com.google.longrunning.Operation>
-      getBatchPredictMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.automl.v1beta1.BatchPredictRequest, com.google.longrunning.Operation>
         getBatchPredictMethod;
@@ -130,9 +110,7 @@ public final class PredictionServiceGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.automl.v1beta1.PredictionService", "BatchPredict"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "BatchPredict"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -206,7 +184,7 @@ public final class PredictionServiceGrpc {
         com.google.cloud.automl.v1beta1.PredictRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.PredictResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getPredictMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getPredictMethod(), responseObserver);
     }
 
     /**
@@ -230,20 +208,20 @@ public final class PredictionServiceGrpc {
     public void batchPredict(
         com.google.cloud.automl.v1beta1.BatchPredictRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchPredictMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchPredictMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getPredictMethodHelper(),
+              getPredictMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.PredictRequest,
                       com.google.cloud.automl.v1beta1.PredictResponse>(this, METHODID_PREDICT)))
           .addMethod(
-              getBatchPredictMethodHelper(),
+              getBatchPredictMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.automl.v1beta1.BatchPredictRequest,
@@ -306,9 +284,7 @@ public final class PredictionServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.automl.v1beta1.PredictResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getPredictMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getPredictMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -333,7 +309,7 @@ public final class PredictionServiceGrpc {
         com.google.cloud.automl.v1beta1.BatchPredictRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchPredictMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchPredictMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -391,7 +367,7 @@ public final class PredictionServiceGrpc {
      */
     public com.google.cloud.automl.v1beta1.PredictResponse predict(
         com.google.cloud.automl.v1beta1.PredictRequest request) {
-      return blockingUnaryCall(getChannel(), getPredictMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getPredictMethod(), getCallOptions(), request);
     }
 
     /**
@@ -414,8 +390,7 @@ public final class PredictionServiceGrpc {
      */
     public com.google.longrunning.Operation batchPredict(
         com.google.cloud.automl.v1beta1.BatchPredictRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getBatchPredictMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getBatchPredictMethod(), getCallOptions(), request);
     }
   }
 
@@ -471,8 +446,7 @@ public final class PredictionServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.automl.v1beta1.PredictResponse>
         predict(com.google.cloud.automl.v1beta1.PredictRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getPredictMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getPredictMethod(), getCallOptions()), request);
     }
 
     /**
@@ -496,7 +470,7 @@ public final class PredictionServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         batchPredict(com.google.cloud.automl.v1beta1.BatchPredictRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchPredictMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchPredictMethod(), getCallOptions()), request);
     }
   }
 
@@ -595,8 +569,8 @@ public final class PredictionServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new PredictionServiceFileDescriptorSupplier())
-                      .addMethod(getPredictMethodHelper())
-                      .addMethod(getBatchPredictMethodHelper())
+                      .addMethod(getPredictMethod())
+                      .addMethod(getBatchPredictMethod())
                       .build();
         }
       }

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,20 +1,28 @@
 {
-  "updateTime": "2020-03-13T21:40:44.502809Z",
+  "updateTime": "2020-03-17T01:57:42.874489Z",
   "sources": [
     {
       "generator": {
         "name": "artman",
-        "version": "1.1.0",
-        "dockerImage": "googleapis/artman@sha256:f54b7644a1d2e7a37b23f5c0dfe9bba473e41c675002a507a244389e27487ca9"
+        "version": "1.1.1",
+        "dockerImage": "googleapis/artman@sha256:5ef340c8d9334719bc5c6981d95f4a5d2737b0a6a24f2b9a0d430e96fff85c5b"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "b2e2bc62fab90e6829e62d3d189906d9b79899e4",
-        "internalRef": "300817706",
-        "log": "b2e2bc62fab90e6829e62d3d189906d9b79899e4\nUpdates to GCS gRPC API spec:\n\n1. Changed GetIamPolicy and TestBucketIamPermissions to use wrapper messages around google.iam.v1 IAM requests messages, and added CommonRequestParams. This lets us support RequesterPays buckets.\n2. Added a metadata field to GetObjectMediaResponse, to support resuming an object media read safely (by extracting the generation of the object being read, and using it in the resumed read request).\n\nPiperOrigin-RevId: 300817706\n\n7fd916ce12335cc9e784bb9452a8602d00b2516c\nAdd deprecated_collections field for backward-compatiblity in PHP and monolith-generated Python and Ruby clients.\n\nGenerate TopicName class in Java which covers the functionality of both ProjectTopicName and DeletedTopicName. Introduce breaking changes to be fixed by synth.py.\n\nDelete default retry parameters.\n\nRetry codes defs can be deleted once # https://github.com/googleapis/gapic-generator/issues/3137 is fixed.\n\nPiperOrigin-RevId: 300813135\n\n047d3a8ac7f75383855df0166144f891d7af08d9\nfix!: google/rpc refactor ErrorInfo.type to ErrorInfo.reason and comment updates.\n\nPiperOrigin-RevId: 300773211\n\nfae4bb6d5aac52aabe5f0bb4396466c2304ea6f6\nAdding RetryPolicy to pubsub.proto\n\nPiperOrigin-RevId: 300769420\n\n7d569be2928dbd72b4e261bf9e468f23afd2b950\nAdding additional protocol buffer annotations to v3.\n\nPiperOrigin-RevId: 300718800\n\n13942d1a85a337515040a03c5108993087dc0e4f\nAdd logging protos for Recommender v1.\n\nPiperOrigin-RevId: 300689896\n\na1a573c3eecfe2c404892bfa61a32dd0c9fb22b6\nfix: change go package to use cloud.google.com/go/maps\n\nPiperOrigin-RevId: 300661825\n\nc6fbac11afa0c7ab2972d9df181493875c566f77\nfeat: publish documentai/v1beta2 protos\n\nPiperOrigin-RevId: 300656808\n\n5202a9e0d9903f49e900f20fe5c7f4e42dd6588f\nProtos for v1beta1 release of Cloud Security Center Settings API\n\nPiperOrigin-RevId: 300580858\n\n83518e18655d9d4ac044acbda063cc6ecdb63ef8\nAdds gapic.yaml file and BUILD.bazel file.\n\nPiperOrigin-RevId: 300554200\n\n836c196dc8ef8354bbfb5f30696bd3477e8db5e2\nRegenerate recommender v1beta1 gRPC ServiceConfig file for Insights methods.\n\nPiperOrigin-RevId: 300549302\n\n34a5450c591b6be3d6566f25ac31caa5211b2f3f\nIncreases the default timeout from 20s to 30s for MetricService\n\nPiperOrigin-RevId: 300474272\n\n5d8bffe87cd01ba390c32f1714230e5a95d5991d\nfeat: use the latest gapic-generator in WORKSPACE for bazel build.\n\nPiperOrigin-RevId: 300461878\n\nd631c651e3bcfac5d371e8560c27648f7b3e2364\nUpdated the GAPIC configs to include parameters for Backups APIs.\n\nPiperOrigin-RevId: 300443402\n\n678afc7055c1adea9b7b54519f3bdb228013f918\nAdding Game Servers v1beta API.\n\nPiperOrigin-RevId: 300433218\n\n80d2bd2c652a5e213302041b0620aff423132589\nEnable proto annotation and gapic v2 for talent API.\n\nPiperOrigin-RevId: 300393997\n\n85e454be7a353f7fe1bf2b0affb753305785b872\ndocs(google/maps/roads): remove mention of nonexported api\n\nPiperOrigin-RevId: 300367734\n\nbf839ae632e0f263a729569e44be4b38b1c85f9c\nAdding protocol buffer annotations and updated config info for v1 and v2.\n\nPiperOrigin-RevId: 300276913\n\n309b899ca18a4c604bce63882a161d44854da549\nPublish `Backup` APIs and protos.\n\nPiperOrigin-RevId: 300246038\n\neced64c3f122421350b4aca68a28e89121d20db8\nadd PHP client libraries\n\nPiperOrigin-RevId: 300193634\n\n7727af0e39df1ae9ad715895c8576d7b65cf6c6d\nfeat: use the latest gapic-generator and protoc-java-resource-name-plugin in googleapis/WORKSPACE.\n\nPiperOrigin-RevId: 300188410\n\n2a25aa351dd5b5fe14895266aff5824d90ce757b\nBreaking change: remove the ProjectOrTenant resource and its references.\n\nPiperOrigin-RevId: 300182152\n\na499dbb28546379415f51803505cfb6123477e71\nUpdate web risk v1 gapic config and BUILD file.\n\nPiperOrigin-RevId: 300152177\n\n52701da10fec2a5f9796e8d12518c0fe574488fe\nFix: apply appropriate namespace/package options for C#, PHP and Ruby.\n\nPiperOrigin-RevId: 300123508\n\n365c029b8cdb63f7751b92ab490f1976e616105c\nAdd CC targets to the kms protos.\n\nThese are needed by go/tink.\n\nPiperOrigin-RevId: 300038469\n\n4ba9aa8a4a1413b88dca5a8fa931824ee9c284e6\nExpose logo recognition API proto for GA.\n\nPiperOrigin-RevId: 299971671\n\n1c9fc2c9e03dadf15f16b1c4f570955bdcebe00e\nAdding ruby_package option to accessapproval.proto for the Ruby client libraries generation.\n\nPiperOrigin-RevId: 299955924\n\n1cc6f0a7bfb147e6f2ede911d9b01e7a9923b719\nbuild(google/maps/routes): generate api clients\n\nPiperOrigin-RevId: 299955905\n\n29a47c965aac79e3fe8e3314482ca0b5967680f0\nIncrease timeout to 1hr for method `dropRange` in bigtable/admin/v2, which is\nsynced with the timeout setting in gapic_yaml.\n\nPiperOrigin-RevId: 299917154\n\n8f631c4c70a60a9c7da3749511ee4ad432b62898\nbuild(google/maps/roads/v1op): move go to monorepo pattern\n\nPiperOrigin-RevId: 299885195\n\nd66816518844ebbf63504c9e8dfc7133921dd2cd\nbuild(google/maps/roads/v1op): Add bazel build files to generate clients.\n\nPiperOrigin-RevId: 299851148\n\naf7dff701fabe029672168649c62356cf1bb43d0\nAdd LogPlayerReports and LogImpressions to Playable Locations service\n\nPiperOrigin-RevId: 299724050\n\nb6927fca808f38df32a642c560082f5bf6538ced\nUpdate BigQuery Connection API v1beta1 proto: added credential to CloudSqlProperties.\n\nPiperOrigin-RevId: 299503150\n\n91e1fb5ef9829c0c7a64bfa5bde330e6ed594378\nchore: update protobuf (protoc) version to 3.11.2\n\nPiperOrigin-RevId: 299404145\n\n30e36b4bee6749c4799f4fc1a51cc8f058ba167d\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 299399890\n\nffbb493674099f265693872ae250711b2238090c\nfeat: cloudbuild/v1 add new fields and annotate OUTPUT_OUT fields.\n\nPiperOrigin-RevId: 299397780\n\nbc973a15818e00c19e121959832676e9b7607456\nbazel: Fix broken common  dependency\n\nPiperOrigin-RevId: 299397431\n\n71094a343e3b962e744aa49eb9338219537474e4\nchore: bigtable/admin/v2 publish retry config\n\nPiperOrigin-RevId: 299391875\n\n8f488efd7bda33885cb674ddd023b3678c40bd82\nfeat: Migrate logging to GAPIC v2; release new features.\n\nIMPORTANT: This is a breaking change for client libraries\nin all languages.\n\nCommitter: @lukesneeringer, @jskeet\nPiperOrigin-RevId: 299370279\n\n007605bf9ad3a1fd775014ebefbf7f1e6b31ee71\nUpdate API for bigqueryreservation v1beta1.\n- Adds flex capacity commitment plan to CapacityCommitment.\n- Adds methods for getting and updating BiReservations.\n- Adds methods for updating/splitting/merging CapacityCommitments.\n\nPiperOrigin-RevId: 299368059\n\nf0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n"
+        "sha": "b2cf37e7fd62383a811aa4d54d013ecae638851d",
+        "internalRef": "301282503"
+      }
+    },
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "b2cf37e7fd62383a811aa4d54d013ecae638851d",
+        "internalRef": "301282503",
+        "log": "b2cf37e7fd62383a811aa4d54d013ecae638851d\nData Catalog V1 API\n\nPiperOrigin-RevId: 301282503\n\n1976b9981e2900c8172b7d34b4220bdb18c5db42\nCloud DLP api update. Adds missing fields to Finding and adds support for hybrid jobs.\n\nPiperOrigin-RevId: 301205325\n\nae78682c05e864d71223ce22532219813b0245ac\nfix: several sample code blocks in comments are now properly indented for markdown\n\nPiperOrigin-RevId: 301185150\n\ndcd171d04bda5b67db13049320f97eca3ace3731\nPublish Media Translation API V1Beta1\n\nPiperOrigin-RevId: 301180096\n\nff1713453b0fbc5a7544a1ef6828c26ad21a370e\nAdd protos and BUILD rules for v1 API.\n\nPiperOrigin-RevId: 301179394\n\n8386761d09819b665b6a6e1e6d6ff884bc8ff781\nfeat: chromeos/modlab publish protos and config for Chrome OS Moblab API.\n\nPiperOrigin-RevId: 300843960\n\n"
       }
     },
     {
@@ -32,8 +40,7 @@
         "apiName": "automl",
         "apiVersion": "v1beta1",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/automl/artman_automl_v1beta1.yaml"
+        "generator": "bazel"
       }
     },
     {
@@ -42,8 +49,7 @@
         "apiName": "automl",
         "apiVersion": "v1",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/automl/artman_automl_v1.yaml"
+        "generator": "bazel"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -24,12 +24,10 @@ service = 'automl'
 versions = ['v1beta1', 'v1']
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern='/google/cloud/automl/artman_{service}_{version}.yaml',
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)
