### PR TITLE
chore: added cleanup option in the setup ListOperationIT

### DIFF
--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -85,8 +85,10 @@ public class ListOperationStatusTest {
           // delete unused operations.
           try {
             operationsClient.deleteOperation(operationFullPath);
+            System.out.printf("Deleted: %s \n", operationFullPath);
           } catch (ResourceExhaustedException ex) {
             // back off for 1 minute and retry
+            System.out.println("Backing off for 1 minute due to Resource exhaustion.");
             TimeUnit.MINUTES.sleep(1);
           } catch (Exception ex) {
             throw ex;

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -40,7 +40,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ListOperationStatusTest {
-  private static final String PROJECT_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String PROJECT_ID = System.getenv("AUTOML_PROJECT_ID");
   private ByteArrayOutputStream bout;
   private PrintStream out;
   private PrintStream originalPrintStream;

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -73,7 +73,10 @@ public class ListOperationStatusTest {
       List<String> operationFullPathsToBeDeleted = new ArrayList<>();
       for (Operation operation : operationsClient.listOperations(listRequest).iterateAll()) {
         // collect unused operation into the list.
-        operationFullPathsToBeDeleted.add(operation.getName());
+        // Filter: deleting already done operations.
+        if (operation.getDone()) {
+          operationFullPathsToBeDeleted.add(operation.getName());
+        }
       }
 
       if (operationFullPathsToBeDeleted.size() > 300) {

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -74,7 +74,7 @@ public class ListOperationStatusTest {
       for (Operation operation : operationsClient.listOperations(listRequest).iterateAll()) {
         // collect unused operation into the list.
         // Filter: deleting already done operations.
-        if (operation.getDone()) {
+        if (operation.getDone() && !operation.hasError()) {
           operationFullPathsToBeDeleted.add(operation.getName());
         }
       }

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -19,9 +19,16 @@ package com.example.automl;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.google.cloud.automl.v1.AutoMlClient;
+import com.google.cloud.automl.v1.LocationName;
+import com.google.longrunning.ListOperationsRequest;
+import com.google.longrunning.Operation;
+import com.google.longrunning.OperationsClient;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,11 +56,35 @@ public class ListOperationStatusTest {
   }
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     bout = new ByteArrayOutputStream();
     out = new PrintStream(bout);
     originalPrintStream = System.out;
     System.setOut(out);
+
+    // if the LRO status count more than 300, delete all operations.
+    try (AutoMlClient client = AutoMlClient.create()) {
+      OperationsClient operationsClient = client.getOperationsClient();
+      LocationName projectLocation = LocationName.of(PROJECT_ID, "us-central1");
+      ListOperationsRequest listRequest =
+          ListOperationsRequest.newBuilder().setName(projectLocation.toString()).build();
+      List<String> operationFullPathsToBeDeleted = new ArrayList<>();
+      for (Operation operation :
+          operationsClient.listOperations(listRequest).iterateAll()) {
+          // collect unused operation into the list.
+          operationFullPathsToBeDeleted.add(operation.getName());
+      }
+
+      if(operationFullPathsToBeDeleted.size() > 300) {
+        for (String operationFullPath : operationFullPathsToBeDeleted) {
+          // delete unused operations.
+          operationsClient.deleteOperation(operationFullPath);
+        }
+      }else{
+        // Clear the list since we wont anything with the list.
+        operationFullPathsToBeDeleted.clear();
+      }
+    }
   }
 
   @After

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -85,9 +85,9 @@ public class ListOperationStatusTest {
 
         ExponentialBackOff exponentialBackOff = new ExponentialBackOff.Builder()
             .setInitialIntervalMillis(60000)
-            .setMaxElapsedTimeMillis(ExponentialBackOff.DEFAULT_MAX_ELAPSED_TIME_MILLIS)
+            .setMaxElapsedTimeMillis(180000)
             .setRandomizationFactor(0.5)
-            .setMultiplier(1.2)
+            .setMultiplier(1.1)
             .setMaxIntervalMillis(ExponentialBackOff.DEFAULT_MAX_INTERVAL_MILLIS)
             .build();
 

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -86,7 +86,7 @@ public class ListOperationStatusTest {
 
         for (String operationFullPath :
             operationFullPathsToBeDeleted.subList(0, operationFullPathsToBeDeleted.size() / 2)) {
-          // retry_interval * (random value in range [1 - randomization_factor, 1 + randomization_factor])
+          // retry_interval * (random value in range [1 - rand_factor, 1 + rand_factor])
           ExponentialBackOff exponentialBackOff = new ExponentialBackOff.Builder()
               .setInitialIntervalMillis(60000)
               .setMaxElapsedTimeMillis(300000)
@@ -100,8 +100,9 @@ public class ListOperationStatusTest {
             operationsClient.deleteOperation(operationFullPath);
           } catch (ResourceExhaustedException ex) {
             // exponential back off and retry.
-            System.out.println("Backing off for (1 minute + random_val) due to Resource exhaustion.");
             long backOffInMillis = exponentialBackOff.nextBackOffMillis();
+            System.out.printf("Backing off for %d milliseconds "
+                + "due to Resource exhaustion.\n", backOffInMillis);
             if (backOffInMillis < 0) {
               break;
             }

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -69,18 +69,17 @@ public class ListOperationStatusTest {
       ListOperationsRequest listRequest =
           ListOperationsRequest.newBuilder().setName(projectLocation.toString()).build();
       List<String> operationFullPathsToBeDeleted = new ArrayList<>();
-      for (Operation operation :
-          operationsClient.listOperations(listRequest).iterateAll()) {
-          // collect unused operation into the list.
-          operationFullPathsToBeDeleted.add(operation.getName());
+      for (Operation operation : operationsClient.listOperations(listRequest).iterateAll()) {
+        // collect unused operation into the list.
+        operationFullPathsToBeDeleted.add(operation.getName());
       }
 
-      if(operationFullPathsToBeDeleted.size() > 300) {
+      if (operationFullPathsToBeDeleted.size() > 300) {
         for (String operationFullPath : operationFullPathsToBeDeleted) {
           // delete unused operations.
           operationsClient.deleteOperation(operationFullPath);
         }
-      }else{
+      } else {
         // Clear the list since we wont anything with the list.
         operationFullPathsToBeDeleted.clear();
       }

--- a/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
+++ b/samples/snippets/src/test/java/com/example/automl/ListOperationStatusTest.java
@@ -64,7 +64,7 @@ public class ListOperationStatusTest {
     originalPrintStream = System.out;
     System.setOut(out);
 
-    // if the LRO status count more than 300, delete all operations.
+    // if the LRO status count more than 300, delete half of operations.
     try (AutoMlClient client = AutoMlClient.create()) {
       OperationsClient operationsClient = client.getOperationsClient();
       LocationName projectLocation = LocationName.of(PROJECT_ID, "us-central1");
@@ -81,11 +81,11 @@ public class ListOperationStatusTest {
 
       if (operationFullPathsToBeDeleted.size() > 300) {
         System.out.println("Cleaning up...");
-        for (String operationFullPath : operationFullPathsToBeDeleted) {
+        for (String operationFullPath :
+            operationFullPathsToBeDeleted.subList(0, operationFullPathsToBeDeleted.size() / 2)) {
           // delete unused operations.
           try {
             operationsClient.deleteOperation(operationFullPath);
-            System.out.printf("Deleted: %s \n", operationFullPath);
           } catch (ResourceExhaustedException ex) {
             // back off for 1 minute and retry
             System.out.println("Backing off for 1 minute due to Resource exhaustion.");


### PR DESCRIPTION
ListOperation running slower than the usual due to cluttered operations which did not cleaned up. 

AutoML quotas for delete operation 600 requests per minute, and I think 300 is fair enough limit for cleaning up unused operation statuses.

This added cleanup code will only delete only if the count is greater than 300.
